### PR TITLE
Fix #18. Fix shim when loaded using relative src.

### DIFF
--- a/src/adzerk/boot_cljs.clj
+++ b/src/adzerk/boot_cljs.clj
@@ -53,7 +53,8 @@
   function findPrefix() {
     var els = document.getElementsByTagName('script');
     for (var i = 0; i < els.length; i++) {
-      var match = els[i].getAttribute('src').match(shimRegex);
+      var src = els[i].getAttribute('src');
+      var match = src && src.match(shimRegex);
       if (match) {
         return match[1];
       }


### PR DESCRIPTION
Shim now guesses if it was loaded e.g. using src="../shim.js" and uses the same
prefix (../) for script tags it created.
This way shim can be loaded from index.html and posts/foobar.html and
it generates proper relative script tags.

This will generate shim like this:
```js
// boot-cljs shim
(function() {
  var shimRegex = new RegExp('(.*)main.js$');
  function findPrefix() {
    var els = document.getElementsByTagName('script');
    for (var i = 0; i < els.length; i++) {
      var match = els[i].getAttribute('src').match(shimRegex);
      if (match) {
        return match[1];
      }
    }
    return '';
  }
  var prefix = findPrefix();
document.write("<script src='" + prefix + "js/highlight.pack.inc.js'></script>");
document.write("<script src='" + prefix + "out/goog/base.js'></script>");
document.write("<script src='" + prefix + "boot-cljs-main.js'></script>");
document.write("<script>goog.require('main');</script>");
})();
```