### PR TITLE
NOT READY: Fix relative paths

### DIFF
--- a/src/adzerk/boot_cljs.clj
+++ b/src/adzerk/boot_cljs.clj
@@ -68,7 +68,12 @@
 (defn- write-shim!
   [f shim-path incs cljs output-path output-dir]
   (let [output-dir (replace-path shim-path output-dir)
-        scripts  (concat incs [(.getPath (io/file output-dir "goog" "base.js")) output-path])]
+        shim-dir (.getParentFile (io/file shim-path))
+        scripts  (-> incs
+                     (->> (mapv io/file))
+                     (conj (io/file output-dir "goog" "base.js"))
+                     (conj output-path)
+                     (->> (mapv (partial relative-to shim-dir))))]
     (spit f (format shim-js
                     (.getName f)
                     (apply str (map write-src scripts))


### PR DESCRIPTION
@martinklepsch reported that there are problems with how shim currently generates paths.

If shim file (:output-to) is e.g. js/main.js and it'll be loaded using script src="js/main.js" the shim will itself
add "js/" prefix to other files.
Currently each path written to shim file is path to file inside fileset, e.g. "js/out/goog/base.js". Because prefix is added by shim the paths should be relative to shim file instead "out/goog/base.js".

Btw. It seems this (together with sift move) will fix all problems I've had with using public/ prefix to serve files from ring.

Relative-to fixes should be merged to boot first but this branch contains the changes backported for testing.

Blocked by: boot-clj/boot#69