### PR TITLE
update to Clojurescript 0.0-2740

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[adzerk/boot-cljs "0.0-2727-0"] ;; latest release
+[adzerk/boot-cljs "0.0-2740-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -2,11 +2,11 @@
   :dependencies '[[org.clojure/clojure       "1.6.0"     :scope "provided"]
                   [boot/core                 "2.0.0-rc6" :scope "provided"]
                   [adzerk/bootlaces          "0.1.9"     :scope "test"]
-                  [org.clojure/clojurescript "0.0-2727"  :scope "test"]])
+                  [org.clojure/clojurescript "0.0-2740"  :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
 
-(def +version+ "0.0-2727-0")
+(def +version+ "0.0-2740-0")
 
 (bootlaces! +version+)
 

--- a/src/adzerk/boot_cljs.clj
+++ b/src/adzerk/boot_cljs.clj
@@ -14,7 +14,7 @@
 
 (def ^:private deps
   "ClojureScript dependency to load in the pod."
-  '[[org.clojure/clojurescript "0.0-2727"]])
+  '[[org.clojure/clojurescript "0.0-2740"]])
 
 (defn- set-output-dir-opts
   [{:keys [output-dir] :as opts} tmp-out]


### PR DESCRIPTION
`0.0-2740` fixes a bunch of issues for Windows users so I guess it'd be good to update boot-cljs as well.

Maybe it's worth consideration to add some option that influences the version that's used in the pod. 