### PR TITLE
creation of path was using io/file, which on windows converts to single ...

### DIFF
--- a/src/adzerk/boot_cljs/middleware.clj
+++ b/src/adzerk/boot_cljs/middleware.clj
@@ -154,7 +154,7 @@
           rooted-path #(util/rooted-relative docroot (core/tmppath %))
           scripts     (-> (:incs files)
                           (->> (mapv rooted-path))
-                          (conj (io/file output-dir "goog" "base.js"))
+                          (conj (str output-dir "/goog/base.js"))
                           (conj (util/get-name output-to)))]
       (->> (write-body (file->goog (str "boot/cljs/" base-name)))
            (format shim-js shim-name (apply str (map write-src scripts)))


### PR DESCRIPTION
...backslash for js code creating escape chars instead of file separators. forward slash always works in js.